### PR TITLE
Up engine to 0.5.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,5 +2,5 @@ import sbt._
 
 object Dependencies {
   lazy val SparkSql = "org.apache.spark" %% "spark-sql" % "2.2.0"
-  lazy val SourcedEngine = "tech.sourced" % "engine" % "0.4.1"
+  lazy val SourcedEngine = "tech.sourced" % "engine" % "0.5.2"
 }


### PR DESCRIPTION
need update because now engine can skip MissingObjectExceptions.